### PR TITLE
Added a critical section for serial buffer handling

### DIFF
--- a/Grbl_Esp32/serial.cpp
+++ b/Grbl_Esp32/serial.cpp
@@ -19,6 +19,9 @@
 */
 
 #include "grbl.h"
+#include <freertos/task.h>
+
+portMUX_TYPE myMutex = portMUX_INITIALIZER_UNLOCKED;
 
 #define RX_RING_BUFFER (RX_BUFFER_SIZE+1)
 #define TX_RING_BUFFER (TX_BUFFER_SIZE+1)
@@ -106,6 +109,7 @@ void serialCheckTask(void *pvParameters)
 						}
 						// Throw away any unfound extended-ASCII character by not passing it to the serial buffer.
 					} else { // Write character to buffer
+            vTaskEnterCritical(&myMutex);
 						next_head = serial_rx_buffer_head + 1;
 						if (next_head == RX_RING_BUFFER) { next_head = 0; }
 
@@ -114,6 +118,7 @@ void serialCheckTask(void *pvParameters)
 							serial_rx_buffer[serial_rx_buffer_head] = data;
 							serial_rx_buffer_head = next_head;
 						}
+           vTaskExitCritical(&myMutex);
 					}
 			}  // switch data			
 			
@@ -138,14 +143,14 @@ uint8_t serial_read()
   if (serial_rx_buffer_head == tail) {
     return SERIAL_NO_DATA;
   } else {
-    uint8_t data = serial_rx_buffer[tail];
-
+    uint8_t data; 
+    vTaskEnterCritical(&myMutex); // make sure buffer is not modified while reading by newly read chars from the serial when we are here
+    tail = serial_rx_buffer_tail;
+    data = serial_rx_buffer[tail];
     tail++;
     if (tail == RX_RING_BUFFER) { tail = 0; }
     serial_rx_buffer_tail = tail;
-
+    vTaskExitCritical(&myMutex);
     return data;
   }
 }
-
-


### PR DESCRIPTION
As two task can work concurrently, there is a chance of buffer mismanagement. 
I created a critical section around the code that can change serial buffer values to make changes happen atomically (or so I think).